### PR TITLE
GH Actions: Deploy to Heroku on push to main

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,17 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12 # This is the action
+        with:
+          heroku_api_key: ${{secrets.HEROKU_KEY}}
+          heroku_app_name: "osuminimap" #Must be unique in Heroku
+          heroku_email: ${{secrets.HEROKU_EMAIL}}

--- a/server.js
+++ b/server.js
@@ -2,7 +2,20 @@ import express from "express";
 import { engine } from "express-handlebars";
 import fs from "fs";
 
-const credentials = JSON.parse(fs.readFileSync("./credentials.json"));
+const credentials_path = "./credentials.json"
+let credentials = {}
+if (fs.existsSync(credentials_path)) { 
+	Object.assign(credentials, JSON.parse(fs.readFileSync(credentials_path)))
+	console.log(credentials)
+}
+if (process.env.GMAPSKEY) {
+	credentials.mapsKey = process.env.GMAPSKEY
+}
+
+if (!credentials.mapsKey) {
+	throw "Maps key not found"
+}
+
 const port = process.env.PORT || 3000;
 
 const app = express();


### PR DESCRIPTION
I'm sure you'll have opinions about my JS, so hit me with it as a review.

This works by setting a `GMAPSKEY` environment variable in our Heroku config, and using that if the credentials file isn't around.

On your end, you'll have to set `HEROKU_EMAIL` and `HEROKU_KEY` in Settings / Secrets / Actions. HEROKU_EMAIL can be my email, I'll send you my Heroku key on discord.